### PR TITLE
fix: typo in Cargo.toml repository URL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ Handles an SQS event and provides a vec of your type for processing.
 edition = "2018"
 authors = ["Jeremiah Russell <jrussell@jerus.ie>"]
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/jerusdp/lambda-sqs"
+repository = "https://github.com/jerusdp/lambda_sqs"
 readme = "README.md"
 documentation = "https://docs.rs/lambda-sqs"
 categories = ["web-programming"]


### PR DESCRIPTION
Hi @jerusdp. Thanks for this library, it makes creating SQS processing Lambdas a breeze!


The repository URL has a hyphen rather than an underscore. This leads to a broken repository link showing on https://crates.io/crates/lambda_sqs and https://docs.rs/lambda_sqs/0.2.0/lambda_sqs/.